### PR TITLE
fix: removed media query usage by adding a custom breakpoint

### DIFF
--- a/src/components/Section.svelte
+++ b/src/components/Section.svelte
@@ -5,7 +5,7 @@
 	export let classes = '';
 	/** Center content */
 	export let center = false;
-	// tailwind padding
+	// custom padding
 	export let padding = false;
 	// custom styles (f.e. 'padding: 20px')
 	export let customStyles = '';
@@ -33,17 +33,6 @@
 			background-size: 8px 1px;
 		}
 	}
-
-	.defaultPadding {
-		padding-left: 15vw;
-		padding-right: 15vw;
-	}
-	@media screen and (max-width: 1500px) {
-		.defaultPadding {
-			padding-left: 5vw !important;
-			padding-right: 5vw !important;
-		}
-	}
 </style>
 
 <!--
@@ -51,7 +40,7 @@
 	A full-width section
 -->
 <section
-	class="{fullscreen ? 'fullscreen' : 'w-full'} {padding ? 'lg:px-32 md:px-20 px-8' : "defaultPadding"} {center ? 'center' : ''} {classes}"
+	class="{fullscreen ? 'fullscreen' : 'w-full'} {padding ? `${padding}` : "px-5vw 2xl:px-15vw"} {center ? 'center' : ''} {classes}"
 	style={customStyles}
 	id="{id}">
 	<slot />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,3 +1,6 @@
+// eslint sort keys disabled because it doesnt work correctly with the 5vw and 15vw padding properties
+/* eslint-disable sort-keys */
+
 module.exports = {
 	future: {
 		purgeLayersByDefault: true,

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -53,6 +53,13 @@ module.exports = {
 			maxHeight: {
 				0: '0',
 			},
+			padding: {
+				'15vw': '15vw',
+				'5vw': '5vw',
+			},
+			screens: {
+				'2xl': '1536px',
+			},
 			transitionTimingFunction: {
 				default: 'easeInOutExpo',
 				ease: 'ease',


### PR DESCRIPTION
The added breakpoint exists in tailwind v2 but as we are using v1 it was necessary to define it
manually